### PR TITLE
healthd : offline charger fix screen off

### DIFF
--- a/healthd/healthd_draw.h
+++ b/healthd/healthd_draw.h
@@ -84,9 +84,15 @@ class HealthdDraw {
   // true if minui init'ed OK, false if minui init failed
   bool graphics_available;
 
+  // true if kirin found
+  bool is_kirin;
+  uint32_t mMaxBrightness;
+
  private:
   // Configures font using given animation.
   HealthdDraw(animation* anim);
+  // Set brightness
+  void set_brightness(uint32_t value);
 };
 
 #endif  // HEALTHD_DRAW_H

--- a/healthd/healthd_mode_charger.cpp
+++ b/healthd/healthd_mode_charger.cpp
@@ -93,9 +93,9 @@ char* locale;
 
 #define LAST_KMSG_MAX_SZ (32 * 1024)
 
-#define LOGE(x...) KLOG_ERROR("charger", x);
-#define LOGW(x...) KLOG_WARNING("charger", x);
-#define LOGV(x...) KLOG_DEBUG("charger", x);
+#define LOGE(x...) KLOG_ERROR("charger", x); fprintf(stderr,x);
+#define LOGW(x...) KLOG_WARNING("charger", x); fprintf(stderr,x);
+#define LOGV(x...) KLOG_DEBUG("charger", x); fprintf(stderr,x);
 
 namespace android {
 
@@ -300,6 +300,23 @@ void Charger::BlankSecScreen() {
         init_screen_ = true;
     }
 }
+
+void Charger::UpdateLedState() {
+
+    if (!have_battery_state_) return;
+    if (health_info_.battery_level == 0 && health_info_.battery_status == BatteryStatus::UNKNOWN) return ;
+
+    // TODO set led with battery_level in % (0->100%)
+    LOGV("Battery level = %d\n",health_info_.battery_level);
+
+    /*
+    /sys/class/leds/red/brightness
+    /sys/class/leds/green/brightness
+    /sys/class/leds/blue/brightness
+    */
+
+}
+
 
 void Charger::UpdateScreenState(int64_t now) {
     int disp_time;
@@ -632,6 +649,9 @@ void Charger::OnHeartbeat() {
      * screen transitions (animations, etc)
      */
     UpdateScreenState(now);
+
+    // Update Led color
+    UpdateLedState();
 }
 
 void Charger::OnHealthInfoChanged(const ChargerHealthInfo& health_info) {

--- a/healthd/include_charger/charger/healthd_mode_charger.h
+++ b/healthd/include_charger/charger/healthd_mode_charger.h
@@ -103,6 +103,7 @@ class Charger {
     void ProcessHallSensor(int code);
     void HandleInputState(int64_t now);
     void HandlePowerSupplyState(int64_t now);
+    void UpdateLedState();
     int InputCallback(int fd, unsigned int epevents);
     void InitAnimation();
     int RequestEnableSuspend();

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -11,17 +11,6 @@ import /vendor/etc/init/hw/init.${ro.hardware}.rc
 import /system/etc/init/hw/init.usb.configfs.rc
 import /system/etc/init/hw/init.${ro.zygote}.rc
 
-service charger /bin/charger
-    class charger
-    user system
-    group system shell graphics input wakelock
-    capabilities SYS_BOOT
-    seclabel u:r:charger:s0
-
-on boot
-    chown system system /sys/class/power_supply/batery/input_suspend
-    chmod 0777 /sys/class/power_supply/batery/input_suspend
-
 # Cgroups are mounted right before early-init using list from /etc/cgroups.json
 on early-init
     # Disable sysrq from keyboard
@@ -1197,10 +1186,6 @@ on nonencrypted
 
 on property:sys.init_log_level=*
     loglevel ${sys.init_log_level}
-
-on charger && property:ro.hardware=mt*
-    write /sys/class/leds/lcd-backlight/trigger "backlight"
-    write /sys/class/android_usb/android0/enable 1
 
 on charger
     class_start charger


### PR DESCRIPTION
healthd : offline charger fix screen off

When the phone is charging, the animation never turns off on huawei phones. This patch allows you to turn it off by setting the brightness to 0. This problem may also exist on other phone models.

The charge service must be started with the root user to be able to access /sys/class/leds/lcd_backlight0 ....

You must also add this selinux rules :
attribute sysfs_backlight_attr;
allow charger sysfs_backlight_attr:file rw_file_perms;
